### PR TITLE
Add new alias

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -26,3 +26,7 @@ alias dcrc='docker-compose down; docker-compose up --build -d'
 alias lsh='ls -ltrh'
 
 ## grep Aliases
+
+## AWS Aliases
+alias modplat='export AWS_CONFIG_FILE=~/.aws/mod-platform/config'
+alias laaops='export AWS_CONFIG_FILE=~/.aws/laa-ops/config'


### PR DESCRIPTION
Adding new alias to bashrc to allow command to switch between aws-vault
accounts for laa ops and mod platform